### PR TITLE
Fix feed uniqueness check

### DIFF
--- a/vidclone/bin/main.dart
+++ b/vidclone/bin/main.dart
@@ -82,8 +82,7 @@ void main(List<String> arguments) async {
     throw 'Cloner Configuration file contains duplicate feed(s): [${duplicateFeeds.join(", ")}]';
   }
 
-  // Create all the cloners we'll be using
-  final cloners = clonerConfigurations.map((clonerConfiguration) {
+  for (var clonerConfiguration in clonerConfigurations) {
     final feedManager = feedManagerMap[clonerConfiguration.feedManager.id]
       ..configure(clonerConfiguration.feedManager);
     final downloader = downloaderMap[clonerConfiguration.downloader.id]
@@ -94,10 +93,8 @@ void main(List<String> arguments) async {
     final uploader = uploaderMap[clonerConfiguration.uploader.id]
       ..configure(clonerConfiguration.uploader);
 
-    return Cloner(feedManager, downloader, mediaConverter, uploader);
-  }).toList();
+    final cloner = Cloner(feedManager, downloader, mediaConverter, uploader);
 
-  for (var cloner in cloners) {
     print('Processing ${cloner.feedManager.id} ${cloner.feedManager.feedName}');
 
     // Get the latest feed data, or create an empty feed if necessary

--- a/vidlib/lib/src/models/cloner_task_args.dart
+++ b/vidlib/lib/src/models/cloner_task_args.dart
@@ -47,6 +47,6 @@ abstract class ClonerTaskArgs
   // Used only for debug purposes
   @override
   String toString() {
-    return '$id: [${args.join(",")}]';
+    return 'id: $id, args: [${args.join(", ")}]';
   }
 }

--- a/vidlib/lib/src/utilities.dart
+++ b/vidlib/lib/src/utilities.dart
@@ -87,13 +87,14 @@ Future<io.File> ensureLocal(f.File file) async {
 }
 
 // Return a map where the keys are results of calling valueAccessor on an item,
-// and the values are lists of all items that match that value
-Map<Value, List<Item>> reverseMap<Item, Value>(
-    List<Item> list, Value Function(Item) valueAccessor) {
+// and the values are lists of all items with the same value
+Map<Value, Iterable<Item>> mapByValue<Item, Value>(
+    Iterable<Item> list, Value Function(Item) valueAccessor) {
   return list.fold({}, (map, item) {
     final value = valueAccessor(item);
-    map.update(value, (existingList) => [...existingList, item],
-        ifAbsent: () => <Item>[item]);
+    map.update(value, (existingList) {
+      return [...existingList, item];
+    }, ifAbsent: () => <Item>[item]);
     return map;
   });
 }
@@ -103,7 +104,7 @@ Map<Value, List<Item>> reverseMap<Item, Value>(
 // such as accessing one of its property values.
 List<Value> getDuplicatesByAccessor<Item, Value>(
     Iterable<Item> list, Value Function(Item) valueAccessor) {
-  final reversedMap = reverseMap(list, valueAccessor);
+  final reversedMap = mapByValue(list, valueAccessor);
   // Remove all unique values so we're left with only values that are
   // duplicated
   final nonUnique = reversedMap..removeWhere((key, value) => value.length == 1);


### PR DESCRIPTION
Previously the feed uniqueness check (to make sure we're not updating the same feed twice), we were comparing FeedManagers pulled from the same map, so we they were comparing as equal even when they were not. This change avoids that by comparing the data used to create the FeedManager instead.