### PR TITLE
Replace unsupported xml chars

### DIFF
--- a/credits/src/serve/main.mo
+++ b/credits/src/serve/main.mo
@@ -78,15 +78,6 @@ actor Serve {
                 body = Utils.toNat8Array(""); // Send empty icon
                 upgrade = false;
             };
-        } else if (request.uri == "/pr0n") {
-            // https://www.textfixer.com/tools/remove-line-breaks.php
-            // https://onlinestringtools.com/escape-string
-            return {
-                status = Nat16.fromNat(200);
-                headers = Utils.toNat8ArrayTupleArray([("content-type", "text/xml")]);
-                body = Utils.toNat8Array("<?xml version=\"1.0\" encoding=\"UTF-8\"?> <rss xmlns:itunes=\"http://www.itunes.com/dtds/podcast-1.0.dtd\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\" xmlns:atom=\"http://www.w3.org/2005/Atom\" version=\"2.0\"> <channel> <atom:link href=\"http://mikem-18bd0e1e.localhost.run/test\" rel=\"self\" type=\"application/rss+xml\"></atom:link> <title>Sample Feed</title> <link>http://example.com</link> <language>en-us</language> <itunes:subtitle>Just a sample</itunes:subtitle> <itunes:author>Mike Miller</itunes:author> <itunes:summary>A sample feed hosted on the Internet Computer</itunes:summary> <description>A sample feed hosted on the Internet Computer</description> <itunes:owner> <itunes:name>Mike Miller</itunes:name> <itunes:email>mike@videate.org</itunes:email> </itunes:owner> <itunes:explicit>no</itunes:explicit> <itunes:image href=\"https://brianchristner.io/content/images/2016/01/Success-loading.jpg\"></itunes:image> <itunes:category text=\"Arts\"></itunes:category> <item> <title>test</title> <itunes:summary>test</itunes:summary> <description>test</description> <link>http://example.com/podcast-1</link> <enclosure url=\"http://videate.org/local/test.mp4\" type=\"video/mpeg\" length=\"1024\"></enclosure> <pubDate>21 Dec 2016 16:01:07 +0000</pubDate> <itunes:author>Mike Miller</itunes:author> <itunes:duration>00:32:16</itunes:duration> <itunes:explicit>no</itunes:explicit> <guid></guid> </item> </channel> </rss>");
-                upgrade = false;
-            };
         } else if (request.uri == "/fast") {
             // https://www.textfixer.com/tools/remove-line-breaks.php
             // https://onlinestringtools.com/escape-string
@@ -96,18 +87,17 @@ actor Serve {
                 body = Utils.toNat8Array(sampleFeed);
                 upgrade = false;
             };
-        } else if (request.uri == "/query") {
+        } else {
             let uriIter = Text.split(request.uri, #char '/');
             let requestParts = Iter.toArray(uriIter);
-            let feedName = requestParts[1]; // should be 'query'
+            let feedName = requestParts[1];
             Debug.print("generating \"" # feedName # "\" feed");
             var xml = getFeedXml(feedName);
         
             var response = Utils.generateFeedResponse(xml);
-            Debug.print("Returning feed response");
             return response;
         };
-        
+        /* Upgrade response to an update (non-query) call
         // Translate the inputs to the expected types
         var statusNat16 = Nat16.fromNat(200);
         var bodyNat8Array = Utils.toNat8Array("Upgrading to non-query call");
@@ -121,6 +111,7 @@ actor Serve {
         };
         Debug.print("upgrading");
         return response;
+        */
     };
     
     public func http_update(request: Request) : async Response {

--- a/credits/src/serve/rss.mo
+++ b/credits/src/serve/rss.mo
@@ -117,7 +117,7 @@ module {
               }],
               
               // episode list
-              Array.map(feed.mediaList, func(media: Media) : Element { 
+              Array.map([feed.mediaList[0]], func(media: Media) : Element { 
                 let uri = transformUri(media.uri, uriTransformers);
                 {
                   name = "item";

--- a/credits/src/serve/utils.mo
+++ b/credits/src/serve/utils.mo
@@ -6,6 +6,7 @@ import Nat16 "mo:base/Nat16";
 import Word32 "mo:base/Word32";
 import Char "mo:base/Char";
 import Debug "mo:base/Debug";
+import Array "mo:base/Array";
 import Xml "xml";
 import Types "types";
 
@@ -40,10 +41,13 @@ module {
     };
 
     public func toNat8Array(text: Text): [Nat8] {
-        var wordIter = Iter.map(text.chars(), func(c : Char) : Word32 { Char.toWord32(c) });
+        var wordIter = Iter.map(text.chars(), func(c : Char) : Word32 { Word32.fromChar(c) });
         var natIter = Iter.map(wordIter, func(w : Word32) : Nat { Word32.toNat(w) });
-        var nat8Iter = Iter.map(natIter, func(n : Nat) : Nat8 { Nat8.fromNat(n) });
-        return Iter.toArray(nat8Iter);
+        // Avoid overflow by replacing all ascii characters above 126 with "~" (126)
+        var sanitizedNatIter = Iter.map(natIter, func(n : Nat) : Nat { Nat.min(n, 126) });
+        var nat8Iter = Iter.map(sanitizedNatIter, func(sn : Nat) : Nat8 { Nat8.fromNat(sn) });
+        var nat8Array: [Nat8] = Iter.toArray(nat8Iter);
+        return nat8Array;
     };
 
     // Translate an array of Text tuples into an array of tuples of Nat8 arrays

--- a/credits/src/serve/xml.mo
+++ b/credits/src/serve/xml.mo
@@ -20,9 +20,12 @@ module {
     };
 
     public func stringifyElement(element: Element, indentationLevel: Nat): Text {
+        // Remove characters not supported in xml
+        let sanitizedText = Text.replace(element.text, #text("&"), "&amp;");
+
         // todo: remove Option.make when the member is changed back to optional
         let attributes = Option.get(Option.make(element.attributes), []);
-        let text = Option.get(Option.make(element.text), "");
+        let text = Option.get(Option.make(sanitizedText), "");
         let children = Option.get(Option.make(element.children), []);
         
         let arr = Array.tabulate<Text>(indentationLevel, func _ { "  " });


### PR DESCRIPTION
Replaces "&" with "&amp" and clips any characters above ascii 126 to 126 (~). Ideally we would be able to return characters outside that range, but to work with ic-http-lambda's interface, we need to fit each character in a Nat8.

Also limits feeds to a single media item to avoid running out of memory on the IC when trying to return large feeds. Obviously not ideal and will be reverted once the memory issue is resolved.