### PR TITLE
Sanitize urls in xml

### DIFF
--- a/credits/src/serve/xml.mo
+++ b/credits/src/serve/xml.mo
@@ -21,18 +21,18 @@ module {
 
     public func stringifyElement(element: Element, indentationLevel: Nat): Text {
         // Remove characters not supported in xml
-        let sanitizedText = Text.replace(element.text, #text("&"), "&amp;");
+        func sanitize(str: Text) : Text { Text.replace(str, #text("&"), "&amp;") };
 
         // todo: remove Option.make when the member is changed back to optional
         let attributes = Option.get(Option.make(element.attributes), []);
-        let text = Option.get(Option.make(sanitizedText), "");
+        let text = Option.get(Option.make(sanitize(element.text)), "");
         let children = Option.get(Option.make(element.children), []);
         
         let arr = Array.tabulate<Text>(indentationLevel, func _ { "  " });
         let indent = Array.foldLeft(arr, "", Text.concat);
 
         func foldAttributes(accum: Text, attribute: (Text, Text)): Text {
-            accum # " " # attribute.0 # "=\"" # attribute.1 # "\"";
+            accum # " " # attribute.0 # "=\"" # sanitize(attribute.1) # "\"";
         };
         func foldChildren(accum: Text, child: Element): Text {
             accum # stringifyElement(child, indentationLevel + 1);


### PR DESCRIPTION
Removes ampersands in xml attributes, not just the text. This way, ampersands in file-based links won't fail to parse.