### PR TITLE
Add list of feedUrls to profile

### DIFF
--- a/credits/README.md
+++ b/credits/README.md
@@ -25,10 +25,10 @@ Clone that repository and build and start according to the instructions. The
 startup command is duplicated here for convenience but the Internet Identity
 readme's command should be used (and this should be updated) if they differ.
 
-Run this from the internet-identity folder:
+Run this, updating the path to point to your local copy of internet-identity:
 
 ```bash
-II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet --argument '(null)'
+cd ~/Library/CloudStorage/OneDrive-Personal/Projects/Web/internet-identity/; rm -rf .dfx; II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet --argument '(null)'
 ```
 
 Ensure that the value printed out for "Installing code for canister
@@ -47,7 +47,11 @@ http://localhost:8000/authorize?canisterId=[cid found above]
 
 ### Launch the frontend, hosted in the credits_assets canister
 
-`http://127.0.0.1:8000/?canisterId=`
+`http://127.0.0.1:8000/?canisterId={contributor_assets cid from .dfx/local/canisters}`
+
+If you get a "Register Device. This user does not have access to this wallet."
+page when clicking the login link (likely after a `dfx start --clean`),
+re-deploy the Internet Identity canister by following the instructions above.
 
 ### Rebuild canisters
 

--- a/credits/src/contributor/contributor.mo
+++ b/credits/src/contributor/contributor.mo
@@ -3,31 +3,143 @@ import Hash "mo:base/Hash";
 import Nat "mo:base/Nat";
 import Result "mo:base/Result";
 import Principal "mo:base/Principal";
+import Buffer "mo:base/Buffer";
+import Iter "mo:base/Iter";
+import List "mo:base/List";
+import Array "mo:base/Array";
+import Debug "mo:base/Debug";
+import Option "mo:base/Option";
+import Types "types";
 
 actor Contributor {
-  type Bio = {
-    name: ?Text;
+  public type Bio = Types.Bio;
+  public type Profile = Types.Profile;
+  public type ProfileUpdate = Types.ProfileUpdate;
+  public type Error = Types.Error;
+  type StableContributor = Types.StableContributor;
+
+  private func key(x: Principal) : Trie.Key<Principal> {
+    return { key = x; hash = Principal.hash(x) };
   };
 
-  type Profile = {
-    bio: Bio;
-    id: Principal;
+  private func asStable() : StableContributor = {
+    // Map the (Principal, Profile) pairs from the unstable profiles trie into
+    // a stable array of (Principal, Profile) pairs
+    profileEntries = Iter.toArray(Trie.iter(profiles));
   };
 
-  type ProfileUpdate = {
-    bio: Bio;
-  };
-
-  type Error = {
-    #NotFound;
-    #AlreadyExists;
-    #NotAuthorized;
-  };
-
+  // This pattern uses `preupgrade` and `postupgrade` to allow `profiles` to be
+  // stable even though Trie is not. See
+  // https://sdk.dfinity.org/docs/language-guide/upgrades.html#_preupgrade_and_postupgrade_system_methods
+  
   // Aplication state
-  stable var profiles : Trie.Trie<Principal, Profile> = Trie.empty();
+  stable var stableContributor: StableContributor = { profileEntries = []; };
 
-  // Application interface
+  // There is no Trie.fromArray, so we use a List as an intermediary
+  var profiles : Trie.Trie<Principal, Profile> = Trie.fromList<Principal, Profile>(
+    null,
+    List.fromArray(
+      Array.map<(Principal, Profile), (Trie.Key<Principal>, Profile)>(
+        stableContributor.profileEntries,
+        func ((principal: Principal, profile: Profile)) : (Trie.Key<Principal>, Profile) {
+          return (
+            key(principal),
+            profile
+          );
+        }
+      )
+    ),
+    0
+  );
+
+  system func preupgrade() {
+      stableContributor := asStable();
+  };
+
+  system func postupgrade() {
+      stableContributor := { profileEntries=[]; };
+  };
+
+  public func getAllProfiles(): async Trie.Trie<Principal, Profile> {
+    return profiles;
+  };
+
+  private func getProfile(principal: Principal) : ?Profile {
+    Debug.print("Looking for principal " # Principal.toText(principal));
+
+    return Trie.find(
+      profiles,          // Target trie
+      key(principal),    // Key
+      Principal.equal,   // Equality checker
+    );
+  };
+
+  // Update the profile associated with the given principal, returning the new
+  // profile. A null return value means we did not find a profile to update. 
+  private func updateProfile(principal: Principal, profileUpdate : ProfileUpdate) : async ?Profile {
+    // Associate user profile with their principal
+    let userProfile: Profile = {
+      id = principal;
+      bio = profileUpdate.bio;
+      feedUrls = profileUpdate.feedUrls;
+    };
+
+    switch (getProfile(principal)) {
+      // Do not allow updates to profiles that haven't been created yet
+      case null {
+        return null;
+      };
+      case (? profile) {
+        profiles := Trie.replace(
+          profiles,
+          key(principal),
+          Principal.equal,
+          ?userProfile
+        ).0;
+        return Option.make(userProfile);
+      };
+    };
+  };
+
+  // Public Application Interface
+
+  // Add a feed url to the beginning of the list, or move it to the beginning
+  // if it is already in the array
+  public shared(msg) func addFeedUrl(feedUrl: Text) : async Result.Result<Profile, Error> {
+    // Get caller principal
+    let callerId = msg.caller;
+
+    // Reject the AnonymousIdentity
+    if(Principal.toText(callerId) == "2vxsx-fae") {
+      return #err(#NotAuthorized);
+    };
+
+    switch (getProfile(callerId)) {
+      case null {
+        #err(#NotFound);
+      };
+      case (? existingProfile) {
+        // Update the profile with the new feedUrls since we can't make
+        // feedUrls mutable (it needs to be transfered via candid)
+        let feedUrlsBuffer = Buffer.Buffer<Text>(existingProfile.feedUrls.size());
+        feedUrlsBuffer.add(feedUrl); // Add the new url to the top of the list
+        Iter.iterate(existingProfile.feedUrls.vals(), func(f: Text, _index: Nat) {
+          if (f != feedUrl) { // Skip the new url so we don't store it twice
+            feedUrlsBuffer.add(f);
+          }
+        });
+        let newFeedUrls = feedUrlsBuffer.toArray();
+
+        let profileUpdate: ProfileUpdate = {
+          bio = existingProfile.bio;
+          feedUrls = newFeedUrls;
+        };
+
+        let updatedProfile: ?Profile = await updateProfile(callerId, profileUpdate);
+        return Result.fromOption(updatedProfile, #NotFound);
+      };
+    };
+  };
 
   // Create a profile
   public shared(msg) func create(profile: ProfileUpdate) : async Result.Result<(), Error> {
@@ -43,8 +155,9 @@ actor Contributor {
 
     //Associate user profile with their Principal
     let userProfile: Profile = {
-      bio = profile.bio;
       id = callerId;
+      bio = profile.bio;
+      feedUrls = profile.feedUrls;
     };
 
     let (newProfiles, existing) = Trie.put(
@@ -78,12 +191,8 @@ actor Contributor {
       return #err(#NotAuthorized);
     };
 
-    let result = Trie.find(
-      profiles,          // Target trie
-      key(callerId),     // Key
-      Principal.equal,   // Equality checker
-    );
-    return Result.fromOption(result, #NotFound);
+    let profile = getProfile(callerId);
+    return Result.fromOption(profile, #NotFound);
   };
 
   // Update profile
@@ -96,30 +205,14 @@ actor Contributor {
       return #err(#NotAuthorized);
     };
 
-    // Associate user profile with their principal
-    let userProfile: Profile = {
-        bio = profile.bio;
-        id = callerId;
-    };
-    
-    let result = Trie.find(
-      profiles,
-      key(callerId),
-      Principal.equal
-    );
+    let newProfile = await updateProfile(callerId, profile);
 
-    switch (result) {
-      // Do not allow updates to profiles that haven't been created yet
+    switch (newProfile) {
       case null {
+      // Notify the caller that we did not find a profile to update
         #err(#NotFound);
       };
-      case (? v) {
-        profiles := Trie.replace(
-          profiles,
-          key(callerId),
-          Principal.equal,
-          ?userProfile
-        ).0;
+      case (? profile) {
         #ok(());
       };
     };
@@ -135,18 +228,12 @@ actor Contributor {
       return #err(#NotAuthorized);
     };
 
-    let result = Trie.find(
-      profiles,
-      key(callerId),
-      Principal.equal
-    );
-
-    switch (result) {
+    switch (getProfile(callerId)) {
       // Do not allow updates to profiles that haven't been created yet
       case null {
         #err(#NotFound);
       };
-      case (? v) {
+      case (? profile) {
         profiles := Trie.replace(
           profiles,
           key(callerId),
@@ -156,9 +243,5 @@ actor Contributor {
         #ok(());
       };
     };
-  };
-
-  private func key(x: Principal) : Trie.Key<Principal> {
-    return { key = x; hash = Principal.hash(x) };
   };
 };

--- a/credits/src/contributor/types.mo
+++ b/credits/src/contributor/types.mo
@@ -1,0 +1,32 @@
+import Buffer "mo:base/Buffer";
+import List "mo:base/List";
+
+module {
+  // Used to store the contents of the Contributor canister in stable types
+  // between upgrades
+  public type StableContributor = {
+      profileEntries: [(Principal, Profile)];
+  };
+
+  public type Bio = {
+    name: ?Text;
+  };
+
+  public type Profile = {
+    id: Principal;
+
+    bio: Bio;
+    feedUrls: [Text];
+  };
+
+  public type ProfileUpdate = {
+    bio: Bio;
+    feedUrls: [Text];
+  };
+
+  public type Error = {
+    #NotFound;
+    #AlreadyExists;
+    #NotAuthorized;
+  };
+}

--- a/credits/src/contributor_assets/src/App.tsx
+++ b/credits/src/contributor_assets/src/App.tsx
@@ -55,11 +55,12 @@ export const AppContext = React.createContext<{
   logout: () => void;
   actor?: ActorSubclass<_SERVICE>;
   profile?: ProfileUpdate;
-  setProfile?: React.Dispatch<ProfileUpdate>;
+  setProfile: React.Dispatch<ProfileUpdate>;
 }>({
   login: () => { },
   logout: () => { },
   profile: emptyProfile,
+  setProfile: () => { },
 });
 
 const App = () => {
@@ -83,19 +84,28 @@ const App = () => {
   useEffect(() => {
     const feedUrl = searchParams.get("feedUrl");
     if (feedUrl) {
-      console.log(`Found incoming feed url in searchParams: ${feedUrl}`);
       localStorage.setItem('incomingFeedUrl', feedUrl);
     } else {
-      console.error('No incoming feed url was found in searchParams');
       localStorage.removeItem('incomingFeedUrl');
     }
   }, []);
 
   useEffect(() => {
-    if (profile) {
-      const feedUrl = localStorage.getItem('incomingFeedUrl');
-      console.log(`Adding feedUrl to profile: ${feedUrl}`);
-    }
+    if (profile && actor) {
+      const incomingFeedUrl = localStorage.getItem('incomingFeedUrl');
+      if (incomingFeedUrl) {
+        actor.addFeedUrl(incomingFeedUrl).then((result) => {
+          if ("ok" in result) {
+            toast.success(`Feed Url successfully added.`);
+            setProfile(result.ok);
+            navigate('/manage');
+          } else {
+            toast.error("Error: " + Object.keys(result.err)[0]);
+          };
+        });
+        localStorage.removeItem("incomingFeedUrl");
+      };
+    };
   }, [profile]);
 
   useEffect(() => {

--- a/credits/src/contributor_assets/src/App.tsx
+++ b/credits/src/contributor_assets/src/App.tsx
@@ -15,6 +15,7 @@ import {
   Route,
   Routes,
   useNavigate,
+  useSearchParams,
 } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import CreateProfile from "./components/CreateProfile";
@@ -23,7 +24,6 @@ import { emptyProfile, useAuthClient } from "./hooks";
 import { AuthClient } from "@dfinity/auth-client";
 import { ActorSubclass } from "@dfinity/agent";
 import { useEffect } from "react";
-import { compareProfiles } from './utils';
 
 const Header = styled.header`
   position: relative;
@@ -63,7 +63,6 @@ export const AppContext = React.createContext<{
 });
 
 const App = () => {
-  const history = createBrowserHistory();
   const {
     authClient,
     setAuthClient,
@@ -76,6 +75,28 @@ const App = () => {
     setProfile,
   } = useAuthClient();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // At the page we first land on, record the URL from the search params so we
+  // know which rss feed the user was watching when they clicked the link to
+  // launch this site.
+  useEffect(() => {
+    const feedUrl = searchParams.get("feedUrl");
+    if (feedUrl) {
+      console.log(`Found incoming feed url in searchParams: ${feedUrl}`);
+      localStorage.setItem('incomingFeedUrl', feedUrl);
+    } else {
+      console.error('No incoming feed url was found in searchParams');
+      localStorage.removeItem('incomingFeedUrl');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (profile) {
+      const feedUrl = localStorage.getItem('incomingFeedUrl');
+      console.log(`Adding feedUrl to profile: ${feedUrl}`);
+    }
+  }, [profile]);
 
   useEffect(() => {
     if (actor) {

--- a/credits/src/contributor_assets/src/components/CreateProfile.tsx
+++ b/credits/src/contributor_assets/src/components/CreateProfile.tsx
@@ -21,12 +21,13 @@ const CreateProfile = () => {
     toast.error("There was a problem creating your profile");
   }
 
-  const submitCallback = async (profile: ProfileUpdate) => {
+  const submitCallback = async (profileUpdate: ProfileUpdate) => {
     // Handle creation and verification async
-    actor?.create(profile).then(async (createResponse) => {
+    actor?.create(profileUpdate).then(async (createResponse) => {
       if ("ok" in createResponse) {
         const profileResponse = await actor.read();
         if ("ok" in profileResponse) {
+          setProfile(profileResponse.ok);
           navigate('/manage');
         } else {
           console.error(profileResponse.err);

--- a/credits/src/contributor_assets/src/components/ManageProfile.tsx
+++ b/credits/src/contributor_assets/src/components/ManageProfile.tsx
@@ -14,12 +14,13 @@ import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import {
+  Profile,
   ProfileUpdate,
   _SERVICE,
 } from "../../../declarations/contributor/contributor.did";
 import { AppContext } from "../App";
 import { emptyProfile } from "../hooks";
-import { compareProfiles } from "../utils";
+import { pushProfileUpdate } from "../utils";
 import ProfileForm from "./ProfileForm";
 
 const DetailsList = styled.dl`
@@ -46,31 +47,15 @@ function ManageProfile() {
     }
   };
 
-  const compare = (updatedProfile: ProfileUpdate) => {
-    return compareProfiles(profile, updatedProfile);
-  };
-
-  const submitCallback = (profile: ProfileUpdate) => {
-    toast.success("Contributor profile updated!");
+  const submitCallback = (profileUpdate: ProfileUpdate) => {
     setIsEditing(false);
 
     // Handle update async
-    actor?.update(profile).then(async (profileUpdate) => {
-      if ("ok" in profileUpdate) {
-        const profileResponse = await actor.read();
-        if ("ok" in profileResponse) {
-          // Don't do anything if there is no difference.
-          if (!compare(profileResponse.ok)) return;
-
-          setProfile?.(profileResponse.ok);
-          navigate('/manage');
-        } else {
-          console.error(profileResponse.err);
-          toast.error("Failed to read profile from IC");
-        }
-      } else {
-        console.error(profileUpdate.err);
-        toast.error("Failed to save update to IC");
+    pushProfileUpdate(actor!, profileUpdate).then(async (profile: Profile | undefined) => {
+      if (profile) {
+        toast.success("Contributor profile updated!");
+        setProfile!(profile);
+        navigate('/manage');
       }
     });
   };

--- a/credits/src/contributor_assets/src/components/ManageProfile.tsx
+++ b/credits/src/contributor_assets/src/components/ManageProfile.tsx
@@ -54,7 +54,7 @@ function ManageProfile() {
     pushProfileUpdate(actor!, profileUpdate).then(async (profile: Profile | undefined) => {
       if (profile) {
         toast.success("Contributor profile updated!");
-        setProfile!(profile);
+        setProfile(profile);
         navigate('/manage');
       }
     });
@@ -72,6 +72,7 @@ function ManageProfile() {
   }
 
   const { name } = profile.bio;
+  const { feedUrls } = profile;
 
   // Greet the user
   let fallbackDisplayName = name;
@@ -103,6 +104,14 @@ function ManageProfile() {
               <dt>{name}</dt>
             </Grid>
           </DetailsList>
+          {feedUrls.length == 0 && <Text>No feed URLs found. Please click the Videate link in the shownotes to populate.</Text>}
+          <ul>
+            {feedUrls.map((feedUrl, index) => (
+              <li key={index}>
+                <p>{feedUrl}</p>
+              </li>
+            ))}
+          </ul>
           <ButtonGroup>
             <ActionButton onPress={() => setIsEditing(true)}>
               <Edit />

--- a/credits/src/contributor_assets/src/hooks.ts
+++ b/credits/src/contributor_assets/src/hooks.ts
@@ -75,4 +75,5 @@ export const emptyProfile: ProfileUpdate = {
   bio: {
     name: [],
   },
+  feedUrls: [],
 };

--- a/credits/src/contributor_assets/src/utils.ts
+++ b/credits/src/contributor_assets/src/utils.ts
@@ -1,3 +1,7 @@
+import { ActorSubclass } from "@dfinity/agent";
+import toast from "react-hot-toast";
+import { Profile, ProfileUpdate, _SERVICE } from "../../declarations/contributor/contributor.did";
+
 export function compareProfiles(p1: any | null, p2: any) {
   if (!p1) return false;
 
@@ -9,3 +13,22 @@ export function compareProfiles(p1: any | null, p2: any) {
   }
   return true;
 }
+
+
+export async function pushProfileUpdate(actor: ActorSubclass<_SERVICE>, profileUpdate: ProfileUpdate): Promise<Profile | undefined> {
+  const result = await actor!.update(profileUpdate);
+  if ("ok" in result) {
+    const profileResponse = await actor.read();
+    if ("ok" in profileResponse) {
+      return profileResponse.ok;
+    } else {
+      console.error(profileResponse.err);
+      toast.error("Failed to read profile from IC");
+      return;
+    }
+  } else {
+    console.error(result.err);
+    toast.error("Failed to save update to IC");
+    return;
+  }
+};

--- a/credits/src/contributor_assets/src/utils.ts
+++ b/credits/src/contributor_assets/src/utils.ts
@@ -14,7 +14,6 @@ export function compareProfiles(p1: any | null, p2: any) {
   return true;
 }
 
-
 export async function pushProfileUpdate(actor: ActorSubclass<_SERVICE>, profileUpdate: ProfileUpdate): Promise<Profile | undefined> {
   const result = await actor!.update(profileUpdate);
   if ("ok" in result) {

--- a/credits/src/declarations/contributor/contributor.did
+++ b/credits/src/declarations/contributor/contributor.did
@@ -1,3 +1,9 @@
+type Trie = 
+ variant {
+   branch: Branch;
+   "empty";
+   leaf: Leaf;
+ };
 type Result_1 = 
  variant {
    err: Error;
@@ -8,22 +14,62 @@ type Result =
    err: Error;
    ok;
  };
-type ProfileUpdate = record {bio: Bio;};
+type ProfileUpdate = 
+ record {
+   bio: Bio;
+   feedUrls: vec text;
+ };
 type Profile = 
  record {
    bio: Bio;
+   feedUrls: vec text;
    id: principal;
  };
+type List = 
+ opt record {
+       record {
+         Key;
+         Profile;
+       };
+       List;
+     };
+type Leaf = 
+ record {
+   keyvals: AssocList;
+   size: nat;
+ };
+type Key = 
+ record {
+   hash: Hash;
+   key: principal;
+ };
+type Hash = nat32;
 type Error = 
  variant {
    AlreadyExists;
    NotAuthorized;
    NotFound;
  };
+type Branch = 
+ record {
+   left: Trie;
+   right: Trie;
+   size: nat;
+ };
 type Bio = record {name: opt text;};
+type AssocList = 
+ opt record {
+       record {
+         Key;
+         Profile;
+       };
+       List;
+     };
 service : {
+  addFeedUrl: (text) -> (Result_1);
   create: (ProfileUpdate) -> (Result);
   delete: () -> (Result);
+  getAllProfiles: () -> (Trie);
   read: () -> (Result_1);
   update: (ProfileUpdate) -> (Result);
 }

--- a/credits/src/declarations/contributor/contributor.did.d.ts
+++ b/credits/src/declarations/contributor/contributor.did.d.ts
@@ -1,17 +1,32 @@
 import type { Principal } from '@dfinity/principal';
+export type AssocList = [] | [[[Key, Profile], List]];
 export interface Bio { 'name' : [] | [string] }
+export interface Branch { 'left' : Trie, 'size' : bigint, 'right' : Trie }
 export type Error = { 'NotFound' : null } |
   { 'NotAuthorized' : null } |
   { 'AlreadyExists' : null };
-export interface Profile { 'id' : Principal, 'bio' : Bio }
-export interface ProfileUpdate { 'bio' : Bio }
+export type Hash = number;
+export interface Key { 'key' : Principal, 'hash' : Hash }
+export interface Leaf { 'size' : bigint, 'keyvals' : AssocList }
+export type List = [] | [[[Key, Profile], List]];
+export interface Profile {
+  'id' : Principal,
+  'bio' : Bio,
+  'feedUrls' : Array<string>,
+}
+export interface ProfileUpdate { 'bio' : Bio, 'feedUrls' : Array<string> }
 export type Result = { 'ok' : null } |
   { 'err' : Error };
 export type Result_1 = { 'ok' : Profile } |
   { 'err' : Error };
+export type Trie = { 'branch' : Branch } |
+  { 'leaf' : Leaf } |
+  { 'empty' : null };
 export interface _SERVICE {
+  'addFeedUrl' : (arg_0: string) => Promise<Result_1>,
   'create' : (arg_0: ProfileUpdate) => Promise<Result>,
   'delete' : () => Promise<Result>,
+  'getAllProfiles' : () => Promise<Trie>,
   'read' : () => Promise<Result_1>,
   'update' : (arg_0: ProfileUpdate) => Promise<Result>,
 }

--- a/credits/src/declarations/contributor/contributor.did.js
+++ b/credits/src/declarations/contributor/contributor.did.js
@@ -1,17 +1,41 @@
 export const idlFactory = ({ IDL }) => {
+  const List = IDL.Rec();
+  const Trie = IDL.Rec();
   const Bio = IDL.Record({ 'name' : IDL.Opt(IDL.Text) });
-  const ProfileUpdate = IDL.Record({ 'bio' : Bio });
+  const Profile = IDL.Record({
+    'id' : IDL.Principal,
+    'bio' : Bio,
+    'feedUrls' : IDL.Vec(IDL.Text),
+  });
   const Error = IDL.Variant({
     'NotFound' : IDL.Null,
     'NotAuthorized' : IDL.Null,
     'AlreadyExists' : IDL.Null,
   });
-  const Result = IDL.Variant({ 'ok' : IDL.Null, 'err' : Error });
-  const Profile = IDL.Record({ 'id' : IDL.Principal, 'bio' : Bio });
   const Result_1 = IDL.Variant({ 'ok' : Profile, 'err' : Error });
+  const ProfileUpdate = IDL.Record({
+    'bio' : Bio,
+    'feedUrls' : IDL.Vec(IDL.Text),
+  });
+  const Result = IDL.Variant({ 'ok' : IDL.Null, 'err' : Error });
+  const Branch = IDL.Record({
+    'left' : Trie,
+    'size' : IDL.Nat,
+    'right' : Trie,
+  });
+  const Hash = IDL.Nat32;
+  const Key = IDL.Record({ 'key' : IDL.Principal, 'hash' : Hash });
+  List.fill(IDL.Opt(IDL.Tuple(IDL.Tuple(Key, Profile), List)));
+  const AssocList = IDL.Opt(IDL.Tuple(IDL.Tuple(Key, Profile), List));
+  const Leaf = IDL.Record({ 'size' : IDL.Nat, 'keyvals' : AssocList });
+  Trie.fill(
+    IDL.Variant({ 'branch' : Branch, 'leaf' : Leaf, 'empty' : IDL.Null })
+  );
   return IDL.Service({
+    'addFeedUrl' : IDL.Func([IDL.Text], [Result_1], []),
     'create' : IDL.Func([ProfileUpdate], [Result], []),
     'delete' : IDL.Func([], [Result], []),
+    'getAllProfiles' : IDL.Func([], [Trie], []),
     'read' : IDL.Func([], [Result_1], []),
     'update' : IDL.Func([ProfileUpdate], [Result], []),
   });

--- a/credits/webpack.config.js
+++ b/credits/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = {
       NODE_ENV: "development",
       CONTRIBUTOR_CANISTER_ID: canisters["contributor"],
       II_URL: isDevelopment
-        ? "http://localhost:8000?canisterId=rkp4c-7iaaa-aaaaa-aaaca-cai#authorize"
+        ? "http://localhost:8000?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai#authorize"
         : "https://identity.ic0.app/#authorize",
     }),
     new webpack.ProvidePlugin({


### PR DESCRIPTION
When the user clicks a link in the shownotes, the URL for the feed they were watching will be included as a search param. With this PR, this URL is now stored in the user's profile on the IC, and displayed in a simple list. In the future, this link will be displayed with the user's unique ID appended to it so they can copy it and re-subscribe to the feed with the new URL, which will allow us to track downloads.