### PR TITLE
Ability to customize feed name when cloning

### DIFF
--- a/vidclone/bin/integrations/internet_computer/internet_computer_feed_manager.dart
+++ b/vidclone/bin/integrations/internet_computer/internet_computer_feed_manager.dart
@@ -86,6 +86,9 @@ class CandidResult<V extends CandidValue> {
 class InternetComputerFeedManager extends FeedManager {
   String feedKey;
 
+  @override
+  String feedName;
+
   // "local" to access a locally running IC instance
   // "ic" to use canisters on the IC network
   String network;
@@ -98,11 +101,9 @@ class InternetComputerFeedManager extends FeedManager {
   String get id => 'internet_computer';
 
   @override
-  String get feedName => feedKey;
-
-  @override
   void configure(ClonerTaskArgs feedManagerArgs) {
-    feedKey = feedManagerArgs.get('feedName');
+    feedKey = feedManagerArgs.get('key');
+    feedName = feedManagerArgs.get('name');
     network = feedManagerArgs.get('network').toLowerCase();
     dfxWorkingDirectory = feedManagerArgs.get('dfxWorkingDirectory');
   }
@@ -149,7 +150,7 @@ class InternetComputerFeedManager extends FeedManager {
       'call',
       'serve',
       'addFeed',
-      '("$feedName", $feedCandidString)'
+      '("$feedKey", $feedCandidString)'
     ];
     final output =
         await processRunner('dfx', args, workingDirectory: dfxWorkingDirectory);

--- a/vidclone/pubspec.yaml
+++ b/vidclone/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   googleapis: ^7.0.0
   googleapis_auth: ^1.1.0
   http: ^0.13.1
-  youtube_explode_dart: ^1.10.0
+  youtube_explode_dart: ^1.10.10+2
   dotenv: ^3.0.0
   file: ^6.1.2
   quiver: ^3.0.1


### PR DESCRIPTION
Previously we just used the feedKey as the feed name, but we now require the FeedManagerArgs to specify the feed name so it looks nice when we display it in the Contributor page.