### PR TITLE
Null uploader

### DIFF
--- a/credits/README.md
+++ b/credits/README.md
@@ -89,8 +89,8 @@ Use an existing feed key and the correct local canisterIds for the `serve` and
 
 localhost:8000/example_feed_key?canisterId=r7inp-6aaaa-aaaaa-aaabq-cai&contributorAssetsCid=ryjl3-tyaaa-aaaaa-aaaba-cai&principal=TEST_PRINCIPAL
 
-To test feeds on a phone, use localhost.run to expose the feed to outside
-networks:
+To test locally hosted feeds on a phone, use localhost.run to expose the feed
+to outside networks:
 
 ```
 ssh -R 80:localhost:8000 localhost.run
@@ -99,7 +99,7 @@ ssh -R 80:localhost:8000 localhost.run
 Then subscribe in a podcatcher to the address printed out after "tunneled with
 tls termination", e.g.:
 
-https://8d0116fb626db2.lhrtunnel.link/dfinity?canisterId=r7inp-6aaaa-aaaaa-aaabq-cai&contributorAssetsCid=ryjl3-tyaaa-aaaaa-aaaba-cai&principal=TEST_PRINCIPAL
+https://8d0116fb626db2.lhrtunnel.link/example_feed_key?canisterId=r7inp-6aaaa-aaaaa-aaabq-cai&contributorAssetsCid=ryjl3-tyaaa-aaaaa-aaaba-cai&principal=TEST_PRINCIPAL
 
 Make sure to specify the current cid for contributor_assets from
 .dfx/local/canister_ids.json so the generated videate settings links will work

--- a/vidclone/bin/integrations/local/local_downloader.dart
+++ b/vidclone/bin/integrations/local/local_downloader.dart
@@ -1,6 +1,4 @@
 import 'package:file/local.dart';
-import 'package:vidlib/src/models/media_file.dart';
-import 'package:vidlib/src/models/media.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:vidlib/vidlib.dart';
 import 'dart:io';

--- a/vidclone/bin/integrations/local/null_uploader.dart
+++ b/vidclone/bin/integrations/local/null_uploader.dart
@@ -1,0 +1,57 @@
+import 'package:file/file.dart';
+import 'package:vidlib/vidlib.dart';
+import '../../uploader.dart';
+
+// Does nothing. Does not upload the file anywhere, and simply returns a
+// ServedMedia pointing to the original file.
+class NullUploader extends Uploader {
+  @override
+  String get id => 'null';
+
+  final Directory baseDirectory;
+
+  NullUploader(this.baseDirectory);
+
+  @override
+  void configure(ClonerTaskArgs uploaderArgs) {}
+
+  @override
+  Future<ServedMedia> uploadMedia(MediaFile mediaFile,
+      [Function(double progress) callback]) async {
+    final uri = getDestinationUri(mediaFile.media);
+
+    final servedMedia = ServedMedia((b) => b
+      ..media = mediaFile.media.toBuilder()
+      ..uri = uri
+      ..etag = _generateEtag(mediaFile)
+      ..lengthInBytes = mediaFile.file.lengthSync());
+
+    return servedMedia;
+  }
+
+  String _generateEtag(MediaFile mediaFile) {
+    // Assume a file has not been changed if its size exactly matches. Using a
+    // crypto checksum shoudn't be necessary.
+    return mediaFile.file.lengthSync().toString();
+  }
+
+  @override
+  Uri getDestinationUri(Media media, [extension = 'mp4']) {
+    return media.source.uri;
+  }
+
+  @override
+  Future<ServedMedia> getExistingServedMedia(Media media) async {
+    final uri = getDestinationUri(media);
+    final file = baseDirectory.fileSystem.file(Uri.decodeFull(uri.path));
+    if (!file.existsSync()) {
+      return null;
+    }
+
+    return ServedMedia((b) => b
+      ..uri = uri
+      ..media = media.toBuilder()
+      ..etag = _generateEtag(MediaFile(media, file))
+      ..lengthInBytes = file.lengthSync());
+  }
+}

--- a/vidclone/bin/integrations/media_converters/ffmpeg_media_converter.dart
+++ b/vidclone/bin/integrations/media_converters/ffmpeg_media_converter.dart
@@ -1,6 +1,4 @@
-import 'package:vidlib/src/models/media_file.dart';
 import 'package:vidlib/vidlib.dart';
-import 'package:meta/meta.dart';
 import '../../media_converter.dart';
 
 class FfmpegMediaConverter extends MediaConverter {

--- a/vidclone/bin/main.dart
+++ b/vidclone/bin/main.dart
@@ -9,6 +9,7 @@ import 'integrations/internet_archive/internet_archive_cli_uploader.dart';
 import 'integrations/internet_computer/internet_computer_feed_manager.dart';
 import 'integrations/local/json_file_feed_manager.dart';
 import 'integrations/local/local_downloader.dart';
+import 'integrations/local/null_uploader.dart';
 import 'integrations/local/save_to_disk_uploader.dart';
 import 'integrations/media_converters/ffmpeg_media_converter.dart';
 import 'integrations/media_converters/null_media_converter.dart';
@@ -53,10 +54,11 @@ void main(List<String> arguments) async {
     FfmpegMediaConverter(),
   ];
   final uploaders = [
+    NullUploader(mediaBaseDirectory),
+    SaveToDiskUploader(mediaBaseDirectory),
     Cdn77Uploader(),
     InternetArchiveCliUploader(
         internetArchiveAccessKey, internetArchiveSecretKey),
-    SaveToDiskUploader(mediaBaseDirectory),
   ];
   final feedManagers = [
     JsonFileFeedManager(),

--- a/vidlib/lib/src/video_utilities.dart
+++ b/vidlib/lib/src/video_utilities.dart
@@ -104,7 +104,7 @@ class FfmpegVideoConverter extends Converter<File, Future<File>> {
     ];
     // final command = args.join(' ');
 
-    // ffmpeg -i input.mp4 -vf scale=-2:240 -vcodec libx265 -qscale 3 -crf 28 output.mp4
+    // ffmpeg -i "input.mp4" -vf scale=-2:540 -vcodec libx264 -q:v 3 -crf 28 -movflags +faststart "output.mp4"
     await processStarter('ffmpeg', args).then((p) async {
       p.stderr.transform(Utf8Decoder()).listen((String data) {
         final timeFormat = r'\d{2}:\d{2}:\d{2}\.\d{2}';


### PR DESCRIPTION
Adds an uploader cloner option when cloning, which does not upload or move the file around (like save_to_disk_uploader does) but instead just creates a ServedMedia that points to the original file.