### PR TITLE
Redirect media requests to file

### DIFF
--- a/credits/README.md
+++ b/credits/README.md
@@ -128,7 +128,7 @@ ssh -R 80:localhost:8000 localhost.run
 Then subscribe in a podcatcher to the address printed out after "tunneled with
 tls termination", e.g.:
 
-https://8d0116fb626db2.lhrtunnel.link/example_feed_key?canisterId=r7inp-6aaaa-aaaaa-aaabq-cai&frontendCid=ryjl3-tyaaa-aaaaa-aaaba-cai&principal=TEST_PRINCIPAL
+https://8d0116fb626db2.lhr.life/example_feed_key?canisterId=r7inp-6aaaa-aaaaa-aaabq-cai&frontendCid=ryjl3-tyaaa-aaaaa-aaaba-cai&principal=TEST_PRINCIPAL
 
 Make sure to specify the current cid for frontend from
 .dfx/local/canister_ids.json so the generated videate settings links will work

--- a/credits/src/frontend/src/components/PutFeedForm.tsx
+++ b/credits/src/frontend/src/components/PutFeedForm.tsx
@@ -89,7 +89,7 @@ const PutFeedForm = (): JSX.Element => {
   };
 
   const onSubmit = (feed: Feed): void => {
-    feed.link = "test.com"; //todo: generate correct link using the key and the user's principal
+    feed.link = "http://www.test.com"; //todo: generate correct link using the key and the user's principal
     feed.episodeIds = episodeIds ?? [];
     feed.subtitle = "test subtitle";
     feed.owner = authClient.getIdentity().getPrincipal(); // Feeds are always owned by the user who created them.

--- a/credits/src/serve/types.mo
+++ b/credits/src/serve/types.mo
@@ -29,6 +29,7 @@ module {
   };
 
   public type HttpResponse = {
+    upgrade : Bool;
     status_code : Nat16;
     headers : [HeaderField];
     body : Blob;

--- a/credits/src/serve/utils.mo
+++ b/credits/src/serve/utils.mo
@@ -34,6 +34,7 @@ module {
     var bodyBlob = toBlob(body);
 
     var response : HttpResponse = {
+      upgrade = false;
       status_code = statusNat16;
       headers = headers;
       body = bodyBlob;

--- a/credits/src/serve/utils.mo
+++ b/credits/src/serve/utils.mo
@@ -93,4 +93,32 @@ module {
 
     newBuffer;
   };
+
+  public func getQueryParam(param : Text, url : Text) : ?Text {
+    let splitUrl = Iter.toArray(Text.split(url, #text("?")));
+
+    if (splitUrl.size() == 1) {
+      return null;
+    };
+
+    let queryParamsText : Text = splitUrl[1];
+
+    let queryParamsArray = Iter.toArray(Text.split(queryParamsText, #text("&")));
+    let queryParamsPairs = Array.map<Text, (Text, Text)>(
+      queryParamsArray,
+      func keyAndValue {
+        let pair = Iter.toArray(Text.split(keyAndValue, #text("=")));
+        return (pair[0], pair[1]);
+      },
+    );
+
+    let found = Array.find<(Text, Text)>(
+      queryParamsPairs,
+      func pair { pair.0 == param },
+    );
+    return switch (found) {
+      case null null;
+      case (?f) Option.make(f.1);
+    };
+  };
 };


### PR DESCRIPTION
Lays the groundwork for logging media requests. All links in rss feeds now point to the IC, where they're upgraded to update requests so they can be logged, and then redirected with a 303 status code to the actual media file.